### PR TITLE
Fix contributing heading typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing the the cookbook
+# Contributing to the cookbook
 
 The OpenAI Cookbook is a collection of useful patterns and examples of working with the OpenAI platform, provided as a community resource.
 


### PR DESCRIPTION
## Summary
- fix a typo in the 'Contributing' heading in `CONTRIBUTING.md`

## Testing
- `python .github/scripts/check_notebooks.py` *(fails: ModuleNotFoundError: nbformat)*

------
https://chatgpt.com/codex/tasks/task_e_68415b7a3e508329afe616d62e40ec63